### PR TITLE
fix: support monorepo tsconfig include patterns

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -154,6 +154,41 @@ describe('svelte-fast-check E2E', () => {
     });
   });
 
+  describe('monorepo-project', () => {
+    const projectDir = resolve(fixturesDir, 'monorepo-project');
+
+    afterAll(() => {
+      cleanupCache(projectDir);
+    });
+
+    test('should find svelte files in web/ subdirectory based on tsconfig include', async () => {
+      const config: FastCheckConfig = {
+        rootDir: projectDir,
+        srcDir: resolve(projectDir, 'src'), // This should be ignored, tsconfig.include should take precedence
+      };
+
+      const result = await runFastCheck(config, { quiet: true, svelteWarnings: false });
+
+      // Should find and process svelte files in web/**/*.svelte
+      // No errors expected in the valid monorepo project
+      expect(result.errorCount).toBe(0);
+    });
+
+    test('should work with tsconfig include patterns like web/**/*.svelte', async () => {
+      const config: FastCheckConfig = {
+        rootDir: projectDir,
+        srcDir: resolve(projectDir, 'src'),
+      };
+
+      // The monorepo fixture has tsconfig with include: ["web/**/*.svelte"]
+      // Previously this would return "Found 0 .svelte files"
+      const result = await runFastCheck(config, { quiet: true, svelteWarnings: false });
+
+      // If we found the files, we should have processed them without errors
+      expect(result.diagnostics).toBeDefined();
+    });
+  });
+
   describe('warning-project (svelte compiler warnings)', () => {
     const projectDir = resolve(fixturesDir, 'warning-project');
 

--- a/tests/fixtures/monorepo-project/core/utils.ts
+++ b/tests/fixtures/monorepo-project/core/utils.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/tests/fixtures/monorepo-project/tsconfig.json
+++ b/tests/fixtures/monorepo-project/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "web/**/*.svelte"],
+  "exclude": ["node_modules", "*/dist"]
+}

--- a/tests/fixtures/monorepo-project/web/src/App.svelte
+++ b/tests/fixtures/monorepo-project/web/src/App.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  let count: number = 0;
+  
+  function increment() {
+    count += 1;
+  }
+</script>
+
+<button on:click={increment}>
+  Count: {count}
+</button>


### PR DESCRIPTION
#1

- Read `.svelte` patterns from tsconfig.json `include` field
- Fall back to `src/**/*.svelte` if no patterns found

Note: Type check result differences from svelte-check on [slowreader](https://github.com/hplush/slowreader) will be addressed in a separate PR.