### PR TITLE
feat: add --project flag for monorepo support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ function deriveProjectPaths(tsconfigPath: string): {
   const absolutePath = resolve(process.cwd(), tsconfigPath);
 
   if (!existsSync(absolutePath)) {
-    throw new CliError(`tsconfig.json not found at ${absolutePath}`);
+    throw new CliError(`--project: tsconfig.json not found at ${absolutePath}`);
   }
 
   // rootDir is the directory containing tsconfig.json

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -46,6 +46,7 @@ describe("CLI", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("svelte-fast-check");
+      expect(result.stdout).toContain("--project");
       expect(result.stdout).toContain("--config");
       expect(result.stdout).toContain("--incremental");
     });


### PR DESCRIPTION
## Summary
- Add `--project`/`-p` flag to specify tsconfig.json path for monorepo support
- Derive rootDir from tsconfig.json location
- Add validation: error if `--config` receives .json file with helpful hint
- Add CLI tests for `--project` flag and `--config` validation

## Usage
```bash
# From monorepo root, check specific project
svelte-fast-check --project web/tsconfig.json

# In pre-commit hook
npx svelte-fast-check -p web/tsconfig.json
```

Fixes #6