### PR TITLE
fix: replace Node.js experimental glob with tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@jridgewell/trace-mapping": "^0.3.25",
     "@typescript/native-preview": "^7.0.0-dev.20251229.1",
     "cleye": "^2.2.1",
-    "svelte2tsx": "^0.7.34"
+    "svelte2tsx": "^0.7.34",
+    "tinyglobby": "^0.2.15"
   },
   "peerDependencies": {
     "svelte": ">=5.0.0",


### PR DESCRIPTION
Fixes #20

`fs/promises.glob()` is experimental in Node.js 22+ and causes `SyntaxError: Import named 'glob' not found` on some environments.

Replace with `tinyglobby` - a minimal glob library with only 2 zero-dep dependencies, as suggested in #11.