### PR TITLE
Fix ENOBUFS error on large projects

### DIFF
--- a/src/typecheck/worker.ts
+++ b/src/typecheck/worker.ts
@@ -76,8 +76,14 @@ async function run(input: TypeCheckInput): Promise<TypeCheckOutput> {
         reject(new Error(`tsgo execution failed: ${err.message}`));
       });
 
-      child.on("close", () => {
-        resolve(Buffer.concat(chunks).toString("utf-8"));
+      child.on("close", (code) => {
+        const output = Buffer.concat(chunks).toString("utf-8");
+        if (code !== 0 && output.trim() === "") {
+          return reject(
+            new Error(`tsgo execution failed with exit code ${code}.`),
+          );
+        }
+        resolve(output);
       });
     });
 


### PR DESCRIPTION
## Summary

- Fixes #22
- Use `spawn` instead of `spawnSync` to stream tsgo output without buffer limits

## Problem

`spawnSync` has ~1MB buffer limit. Large projects (1000+ files) exceed this, causing `ENOBUFS` error.

## Solution

Switch to async `spawn` with streaming - no buffer limits.