### PR TITLE
fix(typecheck): make exclude config work for imported and .js files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,12 +8,15 @@
         "@jridgewell/trace-mapping": "^0.3.25",
         "@typescript/native-preview": "^7.0.0-dev.20251229.1",
         "cleye": "^2.2.1",
+        "picomatch": "^4.0.3",
         "svelte2tsx": "^0.7.34",
+        "tinyglobby": "^0.2.15",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",
         "@types/bun": "^1.3.5",
         "@types/node": "^22.0.0",
+        "@types/picomatch": "^4.0.2",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "tsup": "^8.0.0",
@@ -199,6 +202,8 @@
 
     "@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
+    "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
+
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260102.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260102.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260102.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260102.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260102.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260102.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260102.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260102.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-bGssH/lXZUQdlBTC9Xh5d7pZUzNYOIEuIgE08gDNxb1pUDjy/XS2hd1XpSsb4ytfo+NKeToWHIvpzx0QS9yz2A=="],
 
     "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260102.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dns0pWw5TTBmFy0ShQgRaYZcjoQ1uELjXvHIlj3T9qXLnNjsGWkiWt1gcavJ+Z1q+dVGeZYUcWRiUxifG/Yf9w=="],
@@ -335,7 +340,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
@@ -413,11 +418,9 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
-    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@jridgewell/trace-mapping": "^0.3.25",
     "@typescript/native-preview": "^7.0.0-dev.20251229.1",
     "cleye": "^2.2.1",
+    "picomatch": "^4.0.3",
     "svelte2tsx": "^0.7.34",
     "tinyglobby": "^0.2.15"
   },
@@ -50,6 +51,7 @@
     "@biomejs/biome": "^2.3.10",
     "@types/bun": "^1.3.5",
     "@types/node": "^22.0.0",
+    "@types/picomatch": "^4.0.2",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "tsup": "^8.0.0"

--- a/src/typecheck/convert.ts
+++ b/src/typecheck/convert.ts
@@ -446,7 +446,9 @@ export async function generateTsconfig(
       "../node_modules/**",
       // Include excludes from tsconfig.json
       ...(projectTsconfig?.exclude || []).map((p: string) => `../${p}`),
-      ...(config.exclude || []),
+      ...(config.exclude || []).map((p: string) =>
+        p.startsWith("../") ? p : `../${p}`,
+      ),
     ],
   };
 

--- a/src/typecheck/worker.ts
+++ b/src/typecheck/worker.ts
@@ -35,7 +35,7 @@ const require = createRequire(import.meta.url);
  * path matches any `config.exclude` pattern, ensuring excluded files are
  * truly silenced.
  */
-function filterExcludedPaths(
+export function filterExcludedPaths(
   diagnostics: MappedDiagnostic[],
   excludePatterns: string[],
 ): MappedDiagnostic[] {

--- a/tests/unit/exclude.test.ts
+++ b/tests/unit/exclude.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for exclude path filtering logic
+ */
+
+import { describe, expect, test } from "bun:test";
+import { filterExcludedPaths } from "../../src/typecheck/worker";
+import type { MappedDiagnostic } from "../../src/types";
+
+/** Helper to create a mapped diagnostic */
+function makeMappedDiag(
+  originalFile: string,
+  overrides?: Partial<MappedDiagnostic>,
+): MappedDiagnostic {
+  return {
+    file: originalFile,
+    line: 1,
+    column: 1,
+    code: 2322,
+    message: "Type error",
+    severity: "error",
+    originalFile,
+    originalLine: 1,
+    originalColumn: 1,
+    ...overrides,
+  };
+}
+
+describe("filterExcludedPaths", () => {
+  test("should return all diagnostics when exclude patterns are empty", () => {
+    const diagnostics = [
+      makeMappedDiag("src/lib/utils.ts"),
+      makeMappedDiag("src/routes/+page.svelte"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, []);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("should filter diagnostics matching a single glob pattern", () => {
+    const diagnostics = [
+      makeMappedDiag("src/lib/paraglide/messages.js"),
+      makeMappedDiag("src/lib/paraglide/runtime.js"),
+      makeMappedDiag("src/lib/utils.ts"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, ["src/lib/paraglide/**"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].originalFile).toBe("src/lib/utils.ts");
+  });
+
+  test("should keep diagnostics that do not match any pattern", () => {
+    const diagnostics = [
+      makeMappedDiag("src/lib/components/App.svelte"),
+      makeMappedDiag("src/routes/+page.svelte"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, ["src/lib/paraglide/**"]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("should filter diagnostics matching any of multiple patterns", () => {
+    const diagnostics = [
+      makeMappedDiag("src/generated/graphql.ts"),
+      makeMappedDiag("src/lib/paraglide/messages.js"),
+      makeMappedDiag("src/lib/components/App.svelte"),
+      makeMappedDiag("src/routes/+page.svelte"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, [
+      "src/generated/**",
+      "src/lib/paraglide/**",
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].originalFile).toBe("src/lib/components/App.svelte");
+    expect(result[1].originalFile).toBe("src/routes/+page.svelte");
+  });
+
+  test("should filter diagnostics matching an exact file path pattern", () => {
+    const diagnostics = [
+      makeMappedDiag("src/auto.d.ts"),
+      makeMappedDiag("src/lib/utils.ts"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, ["src/auto.d.ts"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].originalFile).toBe("src/lib/utils.ts");
+  });
+
+  test("should filter .svelte files matching exclude pattern", () => {
+    const diagnostics = [
+      makeMappedDiag("src/generated/Component.svelte"),
+      makeMappedDiag("src/generated/Other.svelte"),
+      makeMappedDiag("src/lib/Real.svelte"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, [
+      "src/generated/**/*.svelte",
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].originalFile).toBe("src/lib/Real.svelte");
+  });
+
+  test("should handle empty diagnostics array", () => {
+    const result = filterExcludedPaths([], ["src/lib/paraglide/**"]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("should filter deeply nested files with ** glob", () => {
+    const diagnostics = [
+      makeMappedDiag("src/lib/paraglide/messages/en.js"),
+      makeMappedDiag("src/lib/paraglide/messages/ko/nested.js"),
+      makeMappedDiag("src/lib/utils.ts"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, ["src/lib/paraglide/**"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].originalFile).toBe("src/lib/utils.ts");
+  });
+
+  test("should not filter when pattern does not match path structure", () => {
+    const diagnostics = [makeMappedDiag("src/lib/paraglide/messages.js")];
+
+    const result = filterExcludedPaths(diagnostics, ["lib/paraglide/**"]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  test("should filter .js files (common use case for checkJs)", () => {
+    const diagnostics = [
+      makeMappedDiag("src/lib/paraglide/messages.js"),
+      makeMappedDiag("src/lib/paraglide/runtime.js"),
+      makeMappedDiag("src/app.js"),
+    ];
+
+    const result = filterExcludedPaths(diagnostics, [
+      "src/lib/paraglide/**/*.js",
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].originalFile).toBe("src/app.js");
+  });
+});


### PR DESCRIPTION
## Summary

The `exclude` config option in `svelte-fast-check.config.ts` was non-functional. Files matching exclude patterns still produced diagnostics. This PR fixes both root causes.

## Bug 1: Path relativity mismatch

`config.exclude` patterns were inserted into the generated `.fast-check/tsconfig.json` **without** the `../` prefix needed to resolve relative to that directory. The project tsconfig's excludes correctly got `../` prepended, but `config.exclude` did not:

```ts
// Before (broken)
...(config.exclude || []),

// After (fixed)
...(config.exclude || []).map((p: string) =>
  p.startsWith("../") ? p : `../${p}`,
),
```

## Bug 2: No diagnostic-level filtering for imported files

TypeScript's `exclude` in tsconfig only prevents files from being **directly included** by `include` globs. Files reached via `import` statements are still type-checked and produce diagnostics. This is a well-known TypeScript limitation — `svelte-check` handles it with `--ignore`, `svelte-check-rs` handles it with `--ignore`.

Added a post-processing step using `picomatch` that filters diagnostics whose `originalFile` path matches any `config.exclude` pattern. This runs after sourcemap mapping, so it works correctly for both `.svelte` and non-`.svelte` files.

## Testing

- All 61 existing tests pass
- Build succeeds cleanly
- Lint-staged (biome) passes

## Use Case

Auto-generated files (Paraglide, GraphQL codegen, Prisma, etc.) that are imported by application code. With `checkJs: true`, these `.js` files get type-checked and produce errors that cannot be suppressed without this fix.

Fixes #31