### PR TITLE
fix(typecheck): respect tsconfig files in generated .fast-check tsconfig

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -80,7 +80,7 @@ bun svelte-fast-check --incremental
 
 ## 설정
 
-대부분 설정 없이 동작합니다. `tsconfig.json`의 `paths`, `exclude`를 자동으로 읽습니다.
+대부분 설정 없이 동작합니다. `tsconfig.json`의 `paths`, `exclude`, `files`를 자동으로 읽습니다.
 
 커스텀 설정이 필요하면 `svelte-fast-check.config.ts` 파일을 만들면 됩니다.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Or configure in `package.json`:
 
 ## Configuration
 
-Works out of the box for most projects. Automatically reads `paths` and `exclude` from `tsconfig.json`.
+Works out of the box for most projects. Automatically reads `paths`, `exclude`, and `files` from `tsconfig.json`.
 
 For custom configuration, create `svelte-fast-check.config.ts`:
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -150,6 +150,34 @@ describe("svelte-fast-check E2E", () => {
     });
   });
 
+  describe("tsconfig-files-project", () => {
+    const projectDir = resolve(fixturesDir, "tsconfig-files-project");
+    let result: CheckResult;
+
+    beforeAll(async () => {
+      const config: FastCheckConfig = {
+        rootDir: projectDir,
+        srcDir: resolve(projectDir, "src"),
+      };
+      result = await runFastCheck(config, {
+        quiet: true,
+        svelteWarnings: false,
+      });
+    });
+
+    afterAll(() => {
+      cleanupCache(projectDir);
+    });
+
+    test("should respect tsconfig files entries for ambient declarations", () => {
+      // worker-configuration.d.ts is declared via tsconfig files: [] at project root.
+      // Without forwarding tsconfig files into generated .fast-check/tsconfig.json,
+      // this would fail with TS2304 (cannot find name '__WORKER_CONFIGURATION__').
+      expect(result.errorCount).toBe(0);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+  });
+
   describe("monorepo-project", () => {
     const projectDir = resolve(fixturesDir, "monorepo-project");
     let result: CheckResult;

--- a/tests/fixtures/tsconfig-files-project/src/index.ts
+++ b/tests/fixtures/tsconfig-files-project/src/index.ts
@@ -1,0 +1,3 @@
+export function isWorkerEnabled(): boolean {
+  return __WORKER_CONFIGURATION__.enabled;
+}

--- a/tests/fixtures/tsconfig-files-project/tsconfig.json
+++ b/tests/fixtures/tsconfig-files-project/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "files": ["worker-configuration.d.ts"],
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/tsconfig-files-project/worker-configuration.d.ts
+++ b/tests/fixtures/tsconfig-files-project/worker-configuration.d.ts
@@ -1,0 +1,3 @@
+declare const __WORKER_CONFIGURATION__: {
+  enabled: boolean;
+};


### PR DESCRIPTION
## Summary

This PR makes `svelte-fast-check` respect `tsconfig.json` `files` entries when generating `.fast-check/tsconfig.json`.

Previously, we read `compilerOptions` / `include` / `exclude`, but not `files`.
That caused ambient declarations explicitly listed in `tsconfig.files` to work with `tsc` but fail in `svelte-fast-check`.

## Problem

`generateTsconfig` builds its own `files` array (for Svelte shims and SvelteKit app types), which is correct and necessary.
However, project-level `tsconfig.files` entries were ignored.

So setups like:

```json
{
  "files": ["worker-configuration.d.ts"]
}
```

could pass with `tsc` but fail in `svelte-fast-check` (e.g. `Cannot find name ...`).

## Changes

### 1) Fix: forward `tsconfig.files`
- Added `files?: string[]` to parsed tsconfig shape
- Resolved `files` entries relative to project root (same style as include/exclude resolution)
- Merged resolved project files into generated `.fast-check/tsconfig.json` `files`
- Deduplicated generated `files` entries

### 2) Tests
Added E2E coverage for this exact scenario:
- new fixture with `tsconfig.files` pointing to `worker-configuration.d.ts`
- source file references a global declared only in that `.d.ts`
- asserts no type errors

### 3) Docs
Updated docs to reflect that `files` is now auto-read from `tsconfig.json`.

## Validation

- Ran full test suite: `bun test tests/`
- Result: all tests passing